### PR TITLE
Added a new location provider for raw locations even while app is backgrounded/terminated

### DIFF
--- a/BackgroundGeolocation/MAURConfig.h
+++ b/BackgroundGeolocation/MAURConfig.h
@@ -14,7 +14,8 @@
 enum {
     DISTANCE_FILTER_PROVIDER = 0,
     ACTIVITY_PROVIDER = 1,
-    RAW_PROVIDER = 2
+    RAW_PROVIDER = 2,
+    CONTINUOUS_RAW_PROVIDER = 3,
 };
 
 @interface MAURConfig : NSObject <NSCopying>

--- a/BackgroundGeolocation/MAURContinuousRawLocationProvider.h
+++ b/BackgroundGeolocation/MAURContinuousRawLocationProvider.h
@@ -1,0 +1,17 @@
+//
+//  MAURContinuousRawLocationProvider.h
+//  BackgroundGeolocation
+//
+//  Created by Rob Visentin on 6/24/20.
+//
+
+#ifndef MAURContinuousRawLocationProvider_h
+#define MAURContinuousRawLocationProvider_h
+
+#import "MAURAbstractLocationProvider.h"
+
+@interface MAURContinuousRawLocationProvider : MAURAbstractLocationProvider<MAURLocationProvider>
+
+@end
+
+#endif /* MAURContinuousRawLocationProvider_h */

--- a/BackgroundGeolocation/MAURContinuousRawLocationProvider.m
+++ b/BackgroundGeolocation/MAURContinuousRawLocationProvider.m
@@ -1,0 +1,402 @@
+//
+//  MAURContinuousRawLocationProvider.m
+//  BackgroundGeolocation
+//
+//  Created by Rob Visentin on 6/24/20.
+//
+
+#import "MAURContinuousRawLocationProvider.h"
+#import "MAURLogging.h"
+
+#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
+
+#define LOCATION_DENIED         "User denied use of location services."
+#define LOCATION_RESTRICTED     "Application's use of location services is restricted."
+#define LOCATION_NOT_DETERMINED "User undecided on application's use of location services."
+
+static NSString * const TAG = @"ContinuousRawLocationProvider";
+static NSString * const Domain = @"com.marianhello";
+
+enum {
+    maxLocationAgeInSeconds = 30
+};
+
+@interface MAURContinuousRawLocationProvider () <CLLocationManagerDelegate>
+@end
+
+@implementation MAURContinuousRawLocationProvider {
+    BOOL isUpdatingLocation;
+    BOOL isStarted;
+
+    MAUROperationalMode operationMode;
+
+    CLLocationManager *locationManager;
+    CLCircularRegion *monitoredRegion;
+
+    // configurable options
+    MAURConfig *_config;
+}
+
+- (instancetype) init
+{
+    self = [super init];
+
+    if (self) {
+        isUpdatingLocation = NO;
+        monitoredRegion = nil;
+        isStarted = NO;
+    }
+
+    return self;
+}
+
+- (void) onCreate {
+    locationManager = [[CLLocationManager alloc] init];
+
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9.0")) {
+        DDLogDebug(@"%@ >= iOS9 detected", TAG);
+        locationManager.allowsBackgroundLocationUpdates = YES;
+    }
+
+    locationManager.delegate = self;
+}
+
+- (BOOL) onConfigure:(MAURConfig*)config error:(NSError * __autoreleasing *)outError
+{
+    DDLogVerbose(@"%@ configure", TAG);
+    _config = config;
+
+    locationManager.pausesLocationUpdatesAutomatically = [_config pauseLocationUpdates];
+    locationManager.activityType = [_config decodeActivityType];
+    locationManager.distanceFilter = _config.distanceFilter.integerValue; // meters
+    locationManager.desiredAccuracy = [_config decodeDesiredAccuracy];
+
+    return YES;
+}
+
+/**
+ * Turn on background geolocation
+ */
+- (BOOL) onStart:(NSError * __autoreleasing *)outError
+{
+    DDLogInfo(@"%@ will start", TAG);
+
+    NSUInteger authStatus;
+
+    if ([CLLocationManager respondsToSelector:@selector(authorizationStatus)]) { // iOS 4.2+
+        authStatus = [CLLocationManager authorizationStatus];
+
+        if (authStatus == kCLAuthorizationStatusDenied) {
+            if (outError != NULL) {
+                NSDictionary *errorDictionary = @{
+                                                  NSLocalizedDescriptionKey: NSLocalizedString(@LOCATION_DENIED, nil)
+                                                  };
+
+                *outError = [NSError errorWithDomain:Domain code:MAURBGPermissionDenied userInfo:errorDictionary];
+            }
+
+            return NO;
+        }
+
+        if (authStatus == kCLAuthorizationStatusRestricted) {
+            if (outError != NULL) {
+                NSDictionary *errorDictionary = @{
+                                                  NSLocalizedDescriptionKey: NSLocalizedString(@LOCATION_RESTRICTED, nil)
+                                                  };
+                *outError = [NSError errorWithDomain:Domain code:MAURBGPermissionDenied userInfo:errorDictionary];
+            }
+
+            return NO;
+        }
+
+#ifdef __IPHONE_8_0
+        // we do startUpdatingLocation even though we might not get permissions granted
+        // we can stop later on when recieved callback on user denial
+        // it's neccessary to start call startUpdatingLocation in iOS < 8.0 to show user prompt!
+
+        if (authStatus == kCLAuthorizationStatusNotDetermined) {
+            if ([locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {  //iOS 8.0+
+                DDLogVerbose(@"%@ requestAlwaysAuthorization", TAG);
+                [locationManager requestAlwaysAuthorization];
+            }
+        }
+#endif
+    }
+
+    [self switchMode:MAURForegroundMode];
+
+    isStarted = YES;
+
+    return YES;
+}
+
+/**
+ * Turn it off
+ */
+- (BOOL) onStop:(NSError * __autoreleasing *)outError
+{
+    DDLogInfo(@"%@ stop", TAG);
+
+    [self stopUpdatingLocation];
+    [self stopRegionMonitoring];
+    [self stopMonitoringSignificantLocationChanges];
+
+    isStarted = NO;
+
+    return YES;
+}
+
+- (void) onSwitchMode:(MAUROperationalMode)mode
+{
+    [self switchMode:mode];
+}
+
+/**
+ * toggle between foreground and background operation mode
+ */
+- (void) switchMode:(MAUROperationalMode)mode
+{
+    DDLogInfo(@"%@ switchMode %lu", TAG, (unsigned long)mode);
+
+    operationMode = mode;
+
+    if (operationMode == MAURForegroundMode) {
+        [self stopMonitoringSignificantLocationChanges];
+        [self stopRegionMonitoring];
+    } else if (operationMode == MAURBackgroundMode) {
+        [self startMonitoringSignificantLocationChanges];
+        [self startRegionMonitoring];
+    }
+
+    if (operationMode == MAURForegroundMode || !_config.saveBatteryOnBackground) {
+        [self startUpdatingLocation];
+    } else {
+        [self stopUpdatingLocation];
+    }
+}
+
+- (void) locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations
+{
+    DDLogDebug(@"%@ didUpdateLocations (operationMode: %lu)", TAG, (unsigned long)operationMode);
+
+    if (operationMode == MAURForegroundMode || !_config.saveBatteryOnBackground) {
+        [self startUpdatingLocation];
+    }
+
+    if (operationMode == MAURBackgroundMode) {
+        [self startMonitoringSignificantLocationChanges];
+
+        if (monitoredRegion == nil) {
+            [self startRegionMonitoring];
+        }
+    }
+
+    MAURLocation *bestLocation = nil;
+    for (CLLocation *location in locations) {
+        MAURLocation *bgloc = [MAURLocation fromCLLocation:location];
+
+        // test the age of the location measurement to determine if the measurement is cached
+        // in most cases you will not want to rely on cached measurements
+        if ([bgloc locationAge] > maxLocationAgeInSeconds || ![bgloc hasAccuracy] || ![bgloc hasTime]) {
+            continue;
+        }
+
+        if (bestLocation == nil) {
+            bestLocation = bgloc;
+            continue;
+        }
+
+        if ([bgloc isBetterLocation:bestLocation]) {
+            DDLogInfo(@"Better location found: %@", bgloc);
+            bestLocation = bgloc;
+        }
+    }
+
+    if (bestLocation != nil && monitoredRegion != nil && ![monitoredRegion containsCoordinate:bestLocation.coordinate]) {
+        [self startRegionMonitoring];
+    }
+
+    if (bestLocation != nil) {
+        [super.delegate onLocationChanged:bestLocation];
+    }
+}
+
+- (void) locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region
+{
+    CLLocationDistance radius = [monitoredRegion radius];
+    CLLocationCoordinate2D coordinate = [monitoredRegion center];
+
+    DDLogDebug(@"%@ didExitRegion {%f,%f,%f}", TAG, coordinate.latitude, coordinate.longitude, radius);
+    if ([_config isDebugging]) {
+        AudioServicesPlaySystemSound (exitRegionSound);
+        [self notify:@"Exit stationary region"];
+    }
+
+    MAURLocation *location = [MAURLocation fromCLLocation:manager.location];
+    location.radius = [NSNumber numberWithDouble:radius];
+    location.time = [NSDate date];
+
+    [self startRegionMonitoring];
+
+    [super.delegate onLocationChanged:location];
+}
+
+- (void) locationManagerDidPauseLocationUpdates:(CLLocationManager *)manager
+{
+    DDLogDebug(@"%@ location updates paused", TAG);
+    if ([_config isDebugging]) {
+        [self notify:@"Location updates paused"];
+    }
+}
+
+- (void) locationManagerDidResumeLocationUpdates:(CLLocationManager *)manager
+{
+    DDLogDebug(@"%@ location updates resumed", TAG);
+    if ([_config isDebugging]) {
+        [self notify:@"Location updates resumed b"];
+    }
+}
+
+- (void) locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error
+{
+    DDLogError(@"%@ didFailWithError: %@", TAG, error);
+    if ([_config isDebugging]) {
+        AudioServicesPlaySystemSound (locationErrorSound);
+        [self notify:[NSString stringWithFormat:@"Location error: %@", error.localizedDescription]];
+    }
+
+    switch(error.code) {
+        case kCLErrorLocationUnknown:
+        case kCLErrorNetwork:
+        case kCLErrorRegionMonitoringDenied:
+        case kCLErrorRegionMonitoringSetupDelayed:
+        case kCLErrorRegionMonitoringResponseDelayed:
+        case kCLErrorGeocodeFoundNoResult:
+        case kCLErrorGeocodeFoundPartialResult:
+        case kCLErrorGeocodeCanceled:
+            break;
+        case kCLErrorDenied:
+            break;
+    }
+
+    if (self.delegate && [self.delegate respondsToSelector:@selector(onError:)]) {
+        NSDictionary *errorDictionary = @{
+                                          NSUnderlyingErrorKey : error
+                                          };
+        NSError *outError = [NSError errorWithDomain:Domain code:MAURBGServiceError userInfo:errorDictionary];
+
+        [self.delegate onError:outError];
+    }
+}
+
+- (void) locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status
+{
+    DDLogInfo(@"LocationManager didChangeAuthorizationStatus %u", status);
+    if ([_config isDebugging]) {
+        [self notify:[NSString stringWithFormat:@"Authorization status changed %u", status]];
+    }
+
+    [self switchMode:operationMode];
+
+    switch(status) {
+        case kCLAuthorizationStatusRestricted:
+        case kCLAuthorizationStatusDenied:
+            if (self.delegate && [self.delegate respondsToSelector:@selector(onAuthorizationChanged:)]) {
+                [self.delegate onAuthorizationChanged:MAURLocationAuthorizationDenied];
+            }
+            break;
+        case kCLAuthorizationStatusAuthorizedAlways:
+            if (self.delegate && [self.delegate respondsToSelector:@selector(onAuthorizationChanged:)]) {
+                [self.delegate onAuthorizationChanged:MAURLocationAuthorizationAlways];
+            }
+            break;
+        case kCLAuthorizationStatusAuthorizedWhenInUse:
+            if (self.delegate && [self.delegate respondsToSelector:@selector(onAuthorizationChanged:)]) {
+                [self.delegate onAuthorizationChanged:MAURLocationAuthorizationForeground];
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+- (void) stopUpdatingLocation
+{
+    if (isUpdatingLocation) {
+        [locationManager stopUpdatingLocation];
+        isUpdatingLocation = NO;
+    }
+}
+
+- (void) startUpdatingLocation
+{
+    if (!isUpdatingLocation) {
+        [locationManager startUpdatingLocation];
+        isUpdatingLocation = YES;
+    }
+}
+
+- (void) onTerminate
+{
+    if (isStarted && !_config.stopOnTerminate) {
+        [self stopUpdatingLocation];
+        [self startMonitoringSignificantLocationChanges];
+        [self startRegionMonitoring];
+    }
+}
+
+/**
+ * Creates a new circle around user and region-monitors it for exit
+ */
+- (void) startRegionMonitoring {
+    CLLocation *location = locationManager.location;
+
+    if (location == nil) {
+        return;
+    }
+
+    CLLocationCoordinate2D coord = [location coordinate];
+    DDLogDebug(@"%@ startRegionMonitoring {%f,%f,%@}", TAG, coord.latitude, coord.longitude, _config.stationaryRadius);
+
+    if ([_config isDebugging]) {
+        AudioServicesPlaySystemSound (acquiredLocationSound);
+        [self notify:[NSString stringWithFormat:@"Monitoring region {%f,%f,%@}", coord.latitude, coord.longitude, _config.stationaryRadius]];
+    }
+
+    [self stopRegionMonitoring];
+
+    monitoredRegion = [[CLCircularRegion alloc] initWithCenter:coord radius:_config.stationaryRadius.integerValue identifier:@"ContinuousRawLocation Region"];
+
+    [locationManager startMonitoringForRegion:monitoredRegion];
+}
+
+- (void) stopRegionMonitoring
+{
+    if (monitoredRegion != nil) {
+        [locationManager stopMonitoringForRegion:monitoredRegion];
+        monitoredRegion = nil;
+    }
+}
+
+- (void) startMonitoringSignificantLocationChanges
+{
+    [locationManager startMonitoringSignificantLocationChanges];
+}
+
+- (void) stopMonitoringSignificantLocationChanges
+{
+    [locationManager stopMonitoringSignificantLocationChanges];
+}
+
+- (void) notify:(NSString*)message
+{
+    [super notify:message];
+}
+
+- (void) onDestroy {
+    DDLogInfo(@"Destroying %@ ", TAG);
+    [self onStop:nil];
+}
+
+@end
+

--- a/BackgroundGeolocation/MAURDistanceFilterLocationProvider.m
+++ b/BackgroundGeolocation/MAURDistanceFilterLocationProvider.m
@@ -33,15 +33,16 @@ enum {
 
 @implementation MAURDistanceFilterLocationProvider {
     BOOL isUpdatingLocation;
+    BOOL isAcquiringStationaryLocation;
     BOOL isAcquiringSpeed;
     BOOL isStarted;
-    
+
     CLCircularRegion *stationaryRegion;
     NSDate *stationarySince;
 
     MAUROperationalMode operationMode;
     NSDate *aquireStartTime;
-    
+
     CLLocationManager *locationManager;
 
     // configurable options
@@ -52,9 +53,10 @@ enum {
 - (instancetype) init
 {
     self = [super init];
-    
+
     if (self) {
         isUpdatingLocation = NO;
+        isAcquiringStationaryLocation = NO;
         isAcquiringSpeed = NO;
         stationaryRegion = nil;
         isStarted = NO;
@@ -65,12 +67,12 @@ enum {
 
 - (void) onCreate {
     locationManager = [[CLLocationManager alloc] init];
-    
+
     if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9.0")) {
         DDLogDebug(@"%@ iOS9 detected", TAG);
         locationManager.allowsBackgroundLocationUpdates = YES;
     }
-    
+
     locationManager.delegate = self;
 }
 
@@ -88,7 +90,7 @@ enum {
     locationManager.activityType = [_config decodeActivityType];
     locationManager.distanceFilter = _config.distanceFilter.integerValue; // meters
     locationManager.desiredAccuracy = [_config decodeDesiredAccuracy];
-    
+
     return YES;
 }
 
@@ -98,24 +100,24 @@ enum {
 - (BOOL) onStart:(NSError * __autoreleasing *)outError
 {
     DDLogInfo(@"%@ will start", TAG);
-    
+
     NSUInteger authStatus;
-    
+
     if ([CLLocationManager respondsToSelector:@selector(authorizationStatus)]) { // iOS 4.2+
         authStatus = [CLLocationManager authorizationStatus];
-        
+
         if (authStatus == kCLAuthorizationStatusDenied) {
             if (outError != NULL) {
                 NSDictionary *errorDictionary = @{
                                                   NSLocalizedDescriptionKey: NSLocalizedString(@LOCATION_DENIED, nil)
                                                   };
-                
+
                 *outError = [NSError errorWithDomain:Domain code:MAURBGPermissionDenied userInfo:errorDictionary];
             }
-            
+
             return NO;
         }
-        
+
         if (authStatus == kCLAuthorizationStatusRestricted) {
             if (outError != NULL) {
                 NSDictionary *errorDictionary = @{
@@ -123,15 +125,15 @@ enum {
                                                   };
                 *outError = [NSError errorWithDomain:Domain code:MAURBGPermissionDenied userInfo:errorDictionary];
             }
-            
+
             return NO;
         }
-        
+
 #ifdef __IPHONE_8_0
         // we do startUpdatingLocation even though we might not get permissions granted
         // we can stop later on when recieved callback on user denial
         // it's neccessary to start call startUpdatingLocation in iOS < 8.0 to show user prompt!
-        
+
         if (authStatus == kCLAuthorizationStatusNotDetermined) {
             if ([locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {  //iOS 8.0+
                 DDLogVerbose(@"%@ requestAlwaysAuthorization", TAG);
@@ -140,7 +142,7 @@ enum {
         }
 #endif
     }
-    
+
     [self switchMode:MAURForegroundMode];
 
     isStarted = YES;
@@ -154,8 +156,9 @@ enum {
 - (BOOL) onStop:(NSError * __autoreleasing *)outError
 {
     DDLogInfo(@"%@ stop", TAG);
-    
+
     [self stopUpdatingLocation];
+    [self stopMonitoringSignificantLocationChanges];
     [self stopMonitoringForRegion];
 
     isStarted = NO;
@@ -174,106 +177,122 @@ enum {
 - (void) switchMode:(MAUROperationalMode)mode
 {
     DDLogInfo(@"%@ switchMode %lu", TAG, (unsigned long)mode);
-    
+
     operationMode = mode;
-    
+
     if (operationMode == MAURForegroundMode || !_config.saveBatteryOnBackground) {
         isAcquiringSpeed = YES;
-
+        isAcquiringStationaryLocation = NO;
         [self stopMonitoringForRegion];
-
-        aquireStartTime = [NSDate date];
-        
-        // Crank up the GPS power temporarily to get a good fix on our current location
-        [self stopUpdatingLocation];
-        locationManager.distanceFilter = kCLDistanceFilterNone;
-        locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation;
-        [self startUpdatingLocation];
-        
+        [self stopMonitoringSignificantLocationChanges];
     } else if (operationMode == MAURBackgroundMode) {
         isAcquiringSpeed = NO;
-
-        [self stopUpdatingLocation];
-
-        MAURLocation *stationaryLocation = [MAURLocation fromCLLocation:locationManager.location];
-        stationaryLocation.radius = _config.stationaryRadius;
-        stationaryLocation.time = stationarySince;
-        [self startMonitoringStationaryRegion:stationaryLocation];
+        isAcquiringStationaryLocation = YES;
+        [self startMonitoringSignificantLocationChanges];
     }
 
+    aquireStartTime = [NSDate date];
+
+    // Crank up the GPS power temporarily to get a good fix on our current location
+    [self stopUpdatingLocation];
+    locationManager.distanceFilter = kCLDistanceFilterNone;
+    locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation;
+    [self startUpdatingLocation];
 }
 
 - (void) locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations
 {
     DDLogDebug(@"%@ didUpdateLocations (operationMode: %lu)", TAG, (unsigned long)operationMode);
-    
+
     MAUROperationalMode actAsInMode = operationMode;
-    
+
     if (actAsInMode == MAURBackgroundMode) {
         if ([_config saveBatteryOnBackground] == NO) actAsInMode = MAURForegroundMode;
     }
-    
+
     if (actAsInMode == MAURForegroundMode) {
         if (!isUpdatingLocation) [self startUpdatingLocation];
     }
-    
+
     if (actAsInMode == MAURBackgroundMode) {
-        if (!stationaryRegion) {
+        if (!isAcquiringStationaryLocation && !stationaryRegion) {
             // Perhaps our GPS signal was interupted, re-acquire a stationaryLocation now.
             [self switchMode:operationMode];
         }
     }
-    
-    
+
+
     MAURLocation *bestLocation = nil;
     for (CLLocation *location in locations) {
         MAURLocation *bgloc = [MAURLocation fromCLLocation:location];
-        
+
         // test the age of the location measurement to determine if the measurement is cached
         // in most cases you will not want to rely on cached measurements
         DDLogDebug(@"Location age %f", [bgloc locationAge]);
         if ([bgloc locationAge] > maxLocationAgeInSeconds || ![bgloc hasAccuracy] || ![bgloc hasTime]) {
             continue;
         }
-        
+
         if (bestLocation == nil) {
             bestLocation = bgloc;
             continue;
         }
-        
+
         if ([bgloc isBetterLocation:bestLocation]) {
             DDLogInfo(@"Better location found: %@", bgloc);
             bestLocation = bgloc;
         }
     }
-    
+
     if (bestLocation == nil) {
         return;
     }
-    
+
     // test the measurement to see if it is more accurate than the previous measurement
-    if (isAcquiringSpeed) {
+    if (isAcquiringStationaryLocation) {
+        DDLogDebug(@"%@ acquiring stationary location, accuracy: %@", TAG, bestLocation.accuracy);
         if ([_config isDebugging]) {
             AudioServicesPlaySystemSound (acquiringLocationSound);
         }
-        
+
+        if ([bestLocation.accuracy doubleValue] <= [_config.desiredAccuracy doubleValue]) {
+            DDLogDebug(@"%@ found most accurate stationary before timeout", TAG);
+        } else if (-[aquireStartTime timeIntervalSinceNow] < maxLocationWaitTimeInSeconds) {
+            // we still have time to aquire better location
+            return;
+        }
+
+        isAcquiringStationaryLocation = NO;
+        [self stopUpdatingLocation]; //saving power while monitoring region
+
+        MAURLocation *stationaryLocation = [bestLocation copy];
+        stationaryLocation.radius = _config.stationaryRadius;
+        stationaryLocation.time = stationarySince;
+        [self startMonitoringStationaryRegion:stationaryLocation];
+        // fire onStationary @event for Javascript.
+        [super.delegate onStationaryChanged:stationaryLocation];
+    } else if (isAcquiringSpeed) {
+        if ([_config isDebugging]) {
+            AudioServicesPlaySystemSound (acquiringLocationSound);
+        }
+
         if ([bestLocation.accuracy doubleValue] <= [_config.desiredAccuracy doubleValue]) {
             DDLogDebug(@"%@ found most accurate location before timeout", TAG);
         } else if (-[aquireStartTime timeIntervalSinceNow] < maxLocationWaitTimeInSeconds) {
             // we still have time to aquire better location
             return;
         }
-        
+
         if ([_config isDebugging]) {
             [self notify:@"Aggressive monitoring engaged"];
         }
-        
+
         // We should have a good sample for speed now, power down our GPS as configured by user.
         isAcquiringSpeed = NO;
         locationManager.desiredAccuracy = _config.desiredAccuracy.integerValue;
         locationManager.distanceFilter = [self calculateDistanceFilter:[bestLocation.speed floatValue]];
         [self startUpdatingLocation];
-        
+
     } else if (actAsInMode == MAURForegroundMode) {
         // Adjust distanceFilter incrementally based upon current speed
         float newDistanceFilter = [self calculateDistanceFilter:[bestLocation.speed floatValue]];
@@ -288,7 +307,7 @@ enum {
         }
         [self switchMode:operationMode];
     }
-    
+
     [super.delegate onLocationChanged:bestLocation];
 }
 
@@ -300,19 +319,13 @@ enum {
 {
     CLLocationDistance radius = [region radius];
     CLLocationCoordinate2D coordinate = [region center];
-    
+
     DDLogDebug(@"%@ didExitRegion {%f,%f,%f}", TAG, coordinate.latitude, coordinate.longitude, radius);
     if ([_config isDebugging]) {
         AudioServicesPlaySystemSound (exitRegionSound);
         [self notify:@"Exit stationary region"];
     }
-    
-    MAURLocation *stationaryLocation = [MAURLocation fromCLLocation:manager.location];
-    stationaryLocation.radius = _config.stationaryRadius;
-    stationaryLocation.time = [NSDate date];
-    [self startMonitoringStationaryRegion:stationaryLocation];
-
-    [super.delegate onLocationChanged:stationaryLocation];
+    [self switchMode:operationMode];
 }
 
 - (void) locationManagerDidPauseLocationUpdates:(CLLocationManager *)manager
@@ -338,7 +351,7 @@ enum {
         AudioServicesPlaySystemSound (locationErrorSound);
         [self notify:[NSString stringWithFormat:@"Location error: %@", error.localizedDescription]];
     }
-    
+
     switch(error.code) {
         case kCLErrorLocationUnknown:
         case kCLErrorNetwork:
@@ -352,13 +365,13 @@ enum {
         case kCLErrorDenied:
             break;
     }
-    
+
     if (self.delegate && [self.delegate respondsToSelector:@selector(onError:)]) {
         NSDictionary *errorDictionary = @{
                                           NSUnderlyingErrorKey : error
                                           };
         NSError *outError = [NSError errorWithDomain:Domain code:MAURBGServiceError userInfo:errorDictionary];
-        
+
         [self.delegate onError:outError];
     }
 }
@@ -369,7 +382,7 @@ enum {
     if ([_config isDebugging]) {
         [self notify:[NSString stringWithFormat:@"Authorization status changed %u", status]];
     }
-    
+
     switch(status) {
         case kCLAuthorizationStatusRestricted:
         case kCLAuthorizationStatusDenied:
@@ -411,13 +424,18 @@ enum {
 - (void) onTerminate
 {
     if (isStarted && !_config.stopOnTerminate) {
-       [self stopUpdatingLocation];
-
-       MAURLocation *stationaryLocation = [MAURLocation fromCLLocation:locationManager.location];
-       stationaryLocation.radius = _config.stationaryRadius;
-       stationaryLocation.time = stationarySince;
-       [self startMonitoringStationaryRegion:stationaryLocation];
+        [locationManager startMonitoringSignificantLocationChanges];
     }
+}
+
+- (void) startMonitoringSignificantLocationChanges
+{
+    [locationManager startMonitoringSignificantLocationChanges];
+}
+
+- (void) stopMonitoringSignificantLocationChanges
+{
+    [locationManager stopMonitoringSignificantLocationChanges];
 }
 
 /**
@@ -426,12 +444,12 @@ enum {
 - (void) startMonitoringStationaryRegion:(MAURLocation*)location {
     CLLocationCoordinate2D coord = [location coordinate];
     DDLogDebug(@"%@ startMonitoringStationaryRegion {%f,%f,%@}", TAG, coord.latitude, coord.longitude, _config.stationaryRadius);
-    
+
     if ([_config isDebugging]) {
         AudioServicesPlaySystemSound (acquiredLocationSound);
         [self notify:[NSString stringWithFormat:@"Monitoring region {%f,%f,%@}", location.coordinate.latitude, location.coordinate.longitude, _config.stationaryRadius]];
     }
-    
+
     [self stopMonitoringForRegion];
     stationaryRegion = [[CLCircularRegion alloc] initWithCenter: coord radius:_config.stationaryRadius.integerValue identifier:@"DistanceFilterProvider stationary region"];
     stationaryRegion.notifyOnExit = YES;
@@ -469,12 +487,12 @@ enum {
 {
     CLLocationCoordinate2D regionCenter = [stationaryRegion center];
     BOOL containsCoordinate = [stationaryRegion containsCoordinate:[location coordinate]];
-    
+
     DDLogVerbose(@"%@ location {%@,%@} region {%f,%f,%f} contains: %d",
                  TAG,
                  location.latitude, location.longitude, regionCenter.latitude, regionCenter.longitude,
                  [stationaryRegion radius], containsCoordinate);
-    
+
     return !containsCoordinate;
 }
 

--- a/BackgroundGeolocation/MAURLocation.m
+++ b/BackgroundGeolocation/MAURLocation.m
@@ -214,7 +214,7 @@ MAURLocation* _location;
     if ([key isEqualToString:@"@recordedAt"]) {
         return [NSNumber numberWithDouble:([recordedAt timeIntervalSince1970] * 1000)];
     }
-    
+
     return nil;
 }
 
@@ -227,7 +227,7 @@ MAURLocation* _location;
         MAURLocationMapper *mapper = [MAURLocationMapper map:self];
         return [mapper withDictionary:locationTemplate];
     }
-    
+
     return [self toDictionary];
 }
 
@@ -310,14 +310,12 @@ MAURLocation* _location;
 
 - (BOOL) hasAccuracy
 {
-    if (accuracy == nil || accuracy < 0) return NO;
-    return YES;
+    return (accuracy != nil && accuracy >= 0);
 }
 
 - (BOOL) hasTime
 {
-    if (time != nil && [time timeIntervalSinceNow] > MAX_SECONDS_FROM_NOW) return NO;
-    return YES;
+    return (time != nil && [time timeIntervalSinceNow] <= MAX_SECONDS_FROM_NOW);
 }
 
 - (NSString *) description


### PR DESCRIPTION
* Reverted previous changes to `MAURDistanceFilterLocationProvider` from PR #1. This class didn't fit the bill for what we needed, and rather than massively altering the existing class, this PR adds a new location provider implementation.

* Implemented `MAURContinuousRawLocationProvider`, which provides raw location updates, but adds region and signification location change monitoring to continue to provide updates while the app is backgrounded or terminated.